### PR TITLE
hotfix: dialog of home would visble only flash is existing

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,9 +10,11 @@ module ApplicationHelper
   end
 
   def alert(type, msg)
-    @msg = msg if msg.present?
-    # list of type  => info, complete, warn, danger
-    render "layouts/flash/#{type}"
+    unless flash.empty?
+      # list of type  => info, complete, warn, danger
+      @msg = msg if msg.present?
+      render "layouts/flash/#{type}"
+    end
   end
   include SessionsHelper
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -88,4 +88,12 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     get root_path
     assert flash.empty?
   end
+
+  # =======fix bugs
+  # hotfix/#04_remove_dialog_on_home
+  test 'should create-success dialog disappeared in home' do
+    get root_path
+    assert_select 'div.alert', count: 0
+  end
+  # =======fix bugs end
 end


### PR DESCRIPTION
バグ: [flashの有無に関係なくroot_pathにてダイアログが表示されている]　を修正
バグの修正を行う際にUsersControllerにテストを記述した。
これからバグが起きるたびにテストを記述していくことにする。記述箇所と形式はこのコミットを参考にしてほしい。