### PR TITLE
Feat/#04 strengthen user validation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,8 +11,8 @@ class User < ApplicationRecord
   has_one :user_setting, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 70 }
-  validates :email, presence: true, length: { maximum: 30 }
-  # validates :password, presence: true, length: { minimum: 6 }
+  validates :email, presence: true, length: { maximum: 30 }, uniqueness: true
+  validates :password, presence: true, length: { minimum: 6 }
   has_secure_password
   # これは付け加えるだけで勝手にpassword(digest)を暗号化してくれる
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -89,6 +89,17 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert flash.empty?
   end
 
+  test 'not unique email is notified by flash' do
+    # trying signup with existing email
+    post users_path, params: { user: { name: 'Example User',
+                                       email: User.all[0].email,
+                                       password: 'password',
+                                       password_confirmation: 'password' } }
+    assert_not flash.empty?
+    # flash msg is translated ?
+    assert flash[:notice][0].to_s == 'メールアドレスはすでに存在します'
+  end
+
   # =======fix bugs
   # hotfix/#04_remove_dialog_on_home
   test 'should create-success dialog disappeared in home' do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -13,7 +13,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     # logout
     get logout_url
 
-    # delete user
+    # create user
     assert_difference 'User.count', 1 do
       post users_path, params: { user: { name: 'Example User',
                                          email: 'user@example.com',

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -43,4 +43,16 @@ class UserTest < ActiveSupport::TestCase
     assert_not aki.following?(yuya)
     assert yuya.followers.include?(naoto)
   end
+  test 'email should  be unique ' do
+    # create user with existing email
+    user = User.new(name: 'Example User', email: User.all[0].email,
+                    password: 'foobarbaz', password_confirmation: 'foobarbaz')
+
+    assert_not user.valid?
+
+    # change email to unique
+    user[:email] = 'thisis@unique.com'
+    assert user.save
+    assert user.valid?
+  end
 end


### PR DESCRIPTION
ユーザモデルのメールアドレスについてのバリデーションを追加

それに関連するテストも追加した。
モデルではユニークなemailでパスするかどうか、既存のemailでバリデーションエラーが出るかの二方向からのテストを実施。
コントローラーではflashメッセージが出ているかどうかを確認した