### PR TITLE
feat: add flow of after signup

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,8 +21,8 @@ class UsersController < ApplicationController
       session[:user_id] = @user[:id]
       # set flash
       flash[:notice] = 'アカウントは正常に作成されました'
-
-      redirect_to user_path(@user)
+      flash[:info] = 'あなたのことについて書きましょう'
+      redirect_to edit_user_path(@user)
     else
       flash.now[:notice] = @user.errors.full_messages
       render action: 'new'
@@ -64,7 +64,7 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+    params.require(:user).permit(:name, :email, :password, :password_confirmation, :bio)
   end
 
   def create_user_setting

--- a/app/views/users/_profile.html.erb
+++ b/app/views/users/_profile.html.erb
@@ -1,0 +1,10 @@
+<h3>Edit your profile</h3>
+<%= alert("info",flash[:info])  %>
+<%=form_with(model:@user,local: true,html: {method: :patch}) do |f| %>
+<br>
+<%=f.label "プロフィールメッセージ",:bio  %>
+<br>
+<%=f.text_area :bio %>
+<br>
+<%=f.submit "設定する", disable_with: 'setting'   %>
+<% end  %>

--- a/app/views/users/_setting.html.erb
+++ b/app/views/users/_setting.html.erb
@@ -1,0 +1,33 @@
+<h3>Change your user-settings</h3>
+<%= form_with(model: @user, local: true) do |f| %>
+
+<%= f.label :name %>
+<br>
+<%= f.text_field :name %>
+<br>
+<%= f.label :email %>
+<br>
+<%= f.email_field :email %>
+<br>
+<%= f.label :password %>
+<br>
+<%= f.password_field :password %>
+<br>
+<%= f.label :password_confirmation, "Confirmation" %>
+<br>
+<%= f.password_field :password_confirmation %>
+<br>
+<h3></h3>
+<%= f.submit "Save changes", class: "btn btn-primary" %>
+<br>
+<h3></h3>
+<button><%= link_to "Rest inputting",edit_user_path   %></button>
+<% end %>
+
+<h4>Delete account</h4>
+
+<%= form_with(model:@user,local: true,html: {method: :delete}) do |f| %>
+<%=f.label :password  %>
+<%=f.password_field :password %>
+<%=f.submit "delete account" %>
+<% end  %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,33 +1,3 @@
-<h3>Change your user-settings</h3>
-<%= form_with(model: @user, local: true) do |f| %>
-
-<%= f.label :name %>
-<br>
-<%= f.text_field :name %>
-<br>
-<%= f.label :email %>
-<br>
-<%= f.email_field :email %>
-<br>
-<%= f.label :password %>
-<br>
-<%= f.password_field :password %>
-<br>
-<%= f.label :password_confirmation, "Confirmation" %>
-<br>
-<%= f.password_field :password_confirmation %>
-<br>
-<h3></h3>
-<%= f.submit "Save changes", class: "btn btn-primary" %>
-<br>
-<h3></h3>
-<button><%= link_to "Rest inputting",edit_user_path   %></button>
-<% end %>
-
-<h4>Delete account</h4>
-
-<%= form_with(model:@user,local: true,html: {method: :delete}) do |f| %>
-<%=f.label :password  %>
-<%=f.password_field :password %>
-<%=f.submit "delete account" %>
-<% end  %>
+<%= alert("complete",flash[:notice])  %>
+<%= render "profile" %>
+<%= render "setting" %>

--- a/db/migrate/20221028134405_add_bio_to_user.rb
+++ b/db/migrate/20221028134405_add_bio_to_user.rb
@@ -1,0 +1,5 @@
+class AddBioToUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :bio, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_21_043832) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_28_134405) do
   create_table "comments", force: :cascade do |t|
     t.integer "user_id"
     t.integer "micropost_id"
@@ -83,6 +83,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_21_043832) do
     t.datetime "updated_at", null: false
     t.string "password_digest"
     t.boolean "admin"
+    t.string "bio"
   end
 
   create_table "verifications", force: :cascade do |t|

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -23,12 +23,14 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     # automatically logged in ?
     assert logged_in?
     follow_redirect!
-    assert_template 'users/show'
+    assert_template 'users/edit'
 
     # flash is shown?
     assert_not flash.empty?
     # text of flash is correct ?
     assert flash[:notice] == 'アカウントは正常に作成されました'
+    assert flash[:info] == 'あなたのことについて書きましょう'
+    assert_select 'div.alert', count: 2
 
     # flash msg have disappear after moved page ?
     get root_path


### PR DESCRIPTION
ユーザー登録完了後はプロフィールページへ遷移させ、flashメッセージでプロフィール入力を促す
テストが不十分なので後述のように修正した。flashメッセージの有無と内容の確認だけでなく、それが実際にhtmlで表示されているかを確認するテストも書いた